### PR TITLE
Add missing type declaration on parameter

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -91,7 +91,7 @@ interface AsyncAcceptsCallbackReturnsNothing extends AsyncFunction {
 }
 
 interface AsyncIterableReturnsPromise extends AsyncFunction {
-    (fn: Function): (...args) => {
+    (fn: Function): (...args: any[]) => {
         next(): Promise<{ done: boolean; value?: any; }>;
         forEach(callback: (value: any) => void): Promise<void>;
     };


### PR DESCRIPTION
Needed to support compilation with typescript while using `noImplicitAny`.