### PR TITLE
Fix dependencies, security warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,15 +42,15 @@
   },
   "dependencies": {
     "bluebird": "^3.1.1",
-    "fibers": "^1.0.8",
-    "lodash": "v3.10.1"
+    "fibers": "^2.0.2",
+    "lodash": "^4.17.10"
   },
   "devDependencies": {
     "async": "^1.4.2",
     "asyncx": "^0.4.5",
     "chai": "^3.2.0",
     "co": "^4.6.0",
-    "mocha": "^2.3.2",
+    "mocha": "^5.2.0",
     "mock-fs": "^3.1.0",
     "rewire": "^2.3.4",
     "typescript": "1.7.5"


### PR DESCRIPTION
Some of the dependencies of this package are out of date, causing build errors on node v10.

Specifically, fibers v1 fails to build due to using now deprecated node APIs (fixes #69).

lodash 3.10.1 also contains some security issues, as does the really old version of mocha (2.3.2 -> 5.2.0). mocha is less relevant as its only used during test.

It seems that these changes pass all tests still, and I didn't observe anything breaking.