### PR TITLE
Basic travis-ci integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,33 @@
+language: node_js
+os:
+- linux
+- osx
+node_js:
+- node
+- lts/*
+before_script:
+- npm global add typescript
+cache:
+  directories:
+    - "node_modules"
+before_deploy:
+- npm pack
+deploy:
+- provider: releases
+  api_key: "$GITHUB_TOKEN"
+  file_glob: true
+  file: asyncawait-*.tgz
+  skip_cleanup: true
+  on:
+    branch: master
+    node: node
+    tags: true
+    condition: "$TRAVIS_OS_NAME = linux"
+- provider: npm
+  api_key: "$NPM_TOKEN"
+  skip_cleanup: true
+  email: youremail@yourmail.com
+  on:
+    tags: true
+    node: node
+    condition: "$TRAVIS_OS_NAME = linux"


### PR DESCRIPTION
I also noticed that this project doesn't have any CI, even though it has a test suite.

This PR adds basic CI support, running node LTS/stable on linux and OS X in Travis. 

Theres also some basic support for automatic github release generation and npm package submission, in order to enable this, @yortus should update the email line with an email and insert GITHUB_TOKEN and NPM_TOKEN as secure variables (see https://docs.travis-ci.com/user/environment-variables/#Encrypting-environment-variables). 